### PR TITLE
Fix test environment and document running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ Creates a comprehensive tool to manage building project materials and orders
 
 The API root at `http://127.0.0.1:8000/` will return a simple JSON message.
 
+### Running Tests
+
+Install the optional test dependencies and run the suite with `pytest`:
+
+```bash
+pip install -r requirements.txt
+pytest
+```
+
 ### Available API Endpoints
 
 `app.main` exposes a small REST interface for managing projects. The most

--- a/app/main.py
+++ b/app/main.py
@@ -355,11 +355,3 @@ def export_materials(format: str = "csv"):
     else:
         raise HTTPException(status_code=400, detail="Unsupported format")
 
-from fastapi import FastAPI
-
-app = FastAPI()
-
-@app.get("/")
-def read_root():
-    return {"message": "Project materials API"}
-

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ uvicorn
 pydantic
 jinja2
 fpdf
+httpx
+python-multipart

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,20 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_read_root():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"message": "Project materials API"}
+
+
+def test_create_and_list_project():
+    project = {"id": 1, "name": "Build House"}
+    resp = client.post("/projects", json=project)
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "Build House"
+
+    list_resp = client.get("/projects")
+    assert list_resp.status_code == 200
+    assert any(p["id"] == 1 for p in list_resp.json())


### PR DESCRIPTION
## Summary
- add httpx and python-multipart to requirements
- configure pytest to include repo root on PYTHONPATH
- document how to run the test suite

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68418f42f0f88320981ee1f657c58fcd